### PR TITLE
chore: add docker development environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.github
+vendor
+.phpunit.cache
+.phpunit.result.cache
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM php:8.1-cli
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git \
+        unzip \
+        libzip-dev \
+    && docker-php-ext-install -j"$(nproc)" zip \
+    && rm -rf /var/lib/apt/lists/*
+
+# ext-dom, ext-json, ext-xml are bundled with the base image
+
+RUN pecl install xdebug \
+    && docker-php-ext-enable xdebug
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+WORKDIR /app
+
+CMD ["tail", "-f", "/dev/null"]

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,14 @@
+services:
+  php:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/app
+      - composer_cache:/root/.composer/cache
+    environment:
+      PHP_IDE_CONFIG: "serverName=jira-api-client"
+      XDEBUG_MODE: "off"
+
+volumes:
+  composer_cache:


### PR DESCRIPTION
## Summary
- Add a PHP 8.1 CLI Docker image (Composer + Xdebug) for local development
- Add `compose.yml` mounting the source with a persistent Composer cache
- Add `.dockerignore`

## Test plan
- [x] `docker compose build`
- [x] `docker compose exec php composer install`
- [x] `docker compose exec php vendor/bin/phpunit` (19 tests, 95 assertions, OK)