### PR TITLE
chore: drop PHP 8.1 support and adopt PHP 8.2 features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
 
     tests:
         runs-on: ${{ matrix.operating-system }}
+        permissions:
+            pull-requests: write
         strategy:
             matrix:
                 operating-system: [ ubuntu-latest ]
@@ -88,3 +90,20 @@ jobs:
               with:
                   name: coverage-report
                   path: coverage.xml
+
+            - name: Build coverage summary
+              if: matrix.php-versions == '8.2'
+              uses: irongut/CodeCoverageSummary@v1.3.0
+              with:
+                  filename: coverage.xml
+                  badge: true
+                  format: markdown
+                  output: both
+
+            - name: Comment coverage summary on PR
+              if: matrix.php-versions == '8.2' && github.event_name == 'pull_request'
+              uses: marocchino/sticky-pull-request-comment@v2
+              continue-on-error: true
+              with:
+                  header: coverage
+                  path: code-coverage-results.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
             - name: Run tests with coverage
               if: matrix.php-versions == '8.2'
-              run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.xml
+              run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.xml --coverage-cobertura=coverage-cobertura.xml
 
             - name: Upload coverage report
               if: matrix.php-versions == '8.2'
@@ -95,7 +95,7 @@ jobs:
               if: matrix.php-versions == '8.2'
               uses: irongut/CodeCoverageSummary@v1.3.0
               with:
-                  filename: coverage.xml
+                  filename: coverage-cobertura.xml
                   badge: true
                   format: markdown
                   output: both

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
         strategy:
             matrix:
                 operating-system: [ubuntu-latest]
-                php-versions: ['8.1', '8.2', '8.3', '8.4']
+                php-versions: ['8.2', '8.3', '8.4']
         name: PHP ${{ matrix.php-versions }} Coding standards ${{ matrix.operating-system }}
         steps:
             - name: checkout
@@ -36,7 +36,7 @@ jobs:
         strategy:
             matrix:
                 operating-system: [ ubuntu-latest ]
-                php-versions: [ '8.1', '8.2', '8.3', '8.4' ]
+                php-versions: [ '8.2', '8.3', '8.4' ]
         name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
         steps:
             - name: checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,19 @@ jobs:
               with:
                   php-version: '8.2'
                   extensions: dom, json, xml
+                  tools: composer:v2
+                  coverage: none
+
+            - name: Get composer cache directory
+              id: composer-cache
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+            - name: Cache composer dependencies
+              uses: actions/cache@v4
+              with:
+                  path: ${{ steps.composer-cache.outputs.dir }}
+                  key: ${{ runner.os }}-composer-8.2-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: ${{ runner.os }}-composer-8.2-
 
             - name: Install Composer dependencies
               run: composer install --prefer-dist --no-progress
@@ -43,13 +56,35 @@ jobs:
             - name: Setup PHP, with composer and extensions
               uses: shivammathur/setup-php@v2
               with:
-                    php-version: ${{ matrix.php-versions }}
-                    extensions: dom, json, xml
-                    coverage: xdebug
+                  php-version: ${{ matrix.php-versions }}
+                  extensions: dom, json, xml
+                  tools: composer:v2
+                  coverage: ${{ matrix.php-versions == '8.2' && 'xdebug' || 'none' }}
+
+            - name: Get composer cache directory
+              id: composer-cache
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+            - name: Cache composer dependencies
+              uses: actions/cache@v4
+              with:
+                  path: ${{ steps.composer-cache.outputs.dir }}
+                  key: ${{ runner.os }}-composer-${{ matrix.php-versions }}-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: ${{ runner.os }}-composer-${{ matrix.php-versions }}-
+
             - run: composer install --prefer-dist --no-progress
-            - run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.xml
+
+            - name: Run tests
+              if: matrix.php-versions != '8.2'
+              run: vendor/bin/phpunit
+
+            - name: Run tests with coverage
+              if: matrix.php-versions == '8.2'
+              run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.xml
+
             - name: Upload coverage report
+              if: matrix.php-versions == '8.2'
               uses: actions/upload-artifact@v4
               with:
-                  name: coverage-report-${{ matrix.php-versions }}
+                  name: coverage-report
                   path: coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,8 @@ on:
     pull_request: ~
 jobs:
     coding-standards:
-        runs-on: ${{ matrix.operating-system }}
-        strategy:
-            matrix:
-                operating-system: [ubuntu-latest]
-                php-versions: ['8.2', '8.3', '8.4']
-        name: PHP ${{ matrix.php-versions }} Coding standards ${{ matrix.operating-system }}
+        runs-on: ubuntu-latest
+        name: Coding standards
         steps:
             - name: checkout
               uses: actions/checkout@v4
@@ -20,7 +16,7 @@ jobs:
             - name: Setup PHP, with composer and extensions
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: ${{ matrix.php-versions }}
+                  php-version: '8.2'
                   extensions: dom, json, xml
 
             - name: Install Composer dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thank you for considering contributing to this project! Your help is greatly appreciated. Please follow these guidelines to ensure a smooth contribution process.
 
 ## Prerequisites
-- PHP 8.1 or higher
+- PHP 8.2 or higher
 - Composer
 - Git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-cli
+FROM php:8.2-cli
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git \

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## Prerequisites
 
-This library requires PHP 8.1 or higher and the following PHP extensions:
+This library requires PHP 8.2 or higher and the following PHP extensions:
 - `dom`
 - `json`
 - `xml`

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-xml": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f7ef23dc8c69205b1c8d0e36f5548d3",
+    "content-hash": "b4cf4c32802a804364d4a83b7a567730",
     "packages": [
         {
             "name": "doctrine/deprecations",
@@ -6299,11 +6299,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-xml": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -15,7 +15,7 @@ final class Configuration implements ConfigurationInterface
         $this->host = $host;
     }
 
-    public static function create(string $host, ?string $username = null, ?string $password = null): static
+    public static function create(string $host, ?string $username = null, #[\SensitiveParameter] ?string $password = null): static
     {
         return (new static($host))
             ->setUsername($username)
@@ -51,7 +51,7 @@ final class Configuration implements ConfigurationInterface
         return $this->password;
     }
 
-    public function setPassword(?string $password): static
+    public function setPassword(#[\SensitiveParameter] ?string $password): static
     {
         $this->password = $password;
 

--- a/src/Http/JiraClient.php
+++ b/src/Http/JiraClient.php
@@ -9,7 +9,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Xen3r0\JiraApiClient\Configuration\ConfigurationInterface;
 
-class JiraClient implements JiraClientInterface
+readonly class JiraClient implements JiraClientInterface
 {
     private HttpClientInterface $httpClient;
 

--- a/src/Repository/AbstractRepository.php
+++ b/src/Repository/AbstractRepository.php
@@ -7,7 +7,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 use Xen3r0\JiraApiClient\Http\JiraClientInterface;
 use Xen3r0\JiraApiClient\Serializer\SerializerFactory;
 
-abstract class AbstractRepository
+abstract readonly class AbstractRepository
 {
     private SerializerInterface $serializer;
 

--- a/src/Repository/Issue/CustomFieldOptionRepository.php
+++ b/src/Repository/Issue/CustomFieldOptionRepository.php
@@ -7,7 +7,7 @@ use Xen3r0\JiraApiClient\Model\Issue\CustomFieldOption;
 use Xen3r0\JiraApiClient\Model\Issue\CustomFieldOptionSearchResult;
 use Xen3r0\JiraApiClient\Repository\AbstractRepository;
 
-class CustomFieldOptionRepository extends AbstractRepository implements CustomFieldOptionRepositoryInterface
+readonly class CustomFieldOptionRepository extends AbstractRepository implements CustomFieldOptionRepositoryInterface
 {
     public function findAll(string $fieldId, int $contextId, int $maxResults = 100, int $startAt = 0): CustomFieldOptionSearchResult
     {

--- a/src/Repository/Issue/IssueCommentRepository.php
+++ b/src/Repository/Issue/IssueCommentRepository.php
@@ -8,7 +8,7 @@ use Xen3r0\JiraApiClient\Model\Issue\Comment;
 use Xen3r0\JiraApiClient\Model\Issue\CommentSearchResult;
 use Xen3r0\JiraApiClient\Repository\AbstractRepository;
 
-class IssueCommentRepository extends AbstractRepository implements IssueCommentRepositoryInterface
+readonly class IssueCommentRepository extends AbstractRepository implements IssueCommentRepositoryInterface
 {
     public function findAll(string $issueKey, ?IssueCommentOrder $orderBy = null, int $startAt = 0, int $maxResults = 15): CommentSearchResult
     {

--- a/src/Repository/Issue/IssueRepository.php
+++ b/src/Repository/Issue/IssueRepository.php
@@ -6,7 +6,7 @@ use Xen3r0\JiraApiClient\Model\Issue\Issue;
 use Xen3r0\JiraApiClient\Model\Issue\IssueSearchResult;
 use Xen3r0\JiraApiClient\Repository\AbstractRepository;
 
-class IssueRepository extends AbstractRepository implements IssueRepositoryInterface
+readonly class IssueRepository extends AbstractRepository implements IssueRepositoryInterface
 {
     public function findAll(string $jql, int $maxResults = 15, ?string $nextPageToken = null): IssueSearchResult
     {

--- a/src/Repository/Project/ProjectRepository.php
+++ b/src/Repository/Project/ProjectRepository.php
@@ -6,7 +6,7 @@ use Xen3r0\JiraApiClient\Model\Project\Project;
 use Xen3r0\JiraApiClient\Model\Project\ProjectSearchResult;
 use Xen3r0\JiraApiClient\Repository\AbstractRepository;
 
-class ProjectRepository extends AbstractRepository implements ProjectRepositoryInterface
+readonly class ProjectRepository extends AbstractRepository implements ProjectRepositoryInterface
 {
     public function findAll(?string $query = null, int $maxResults = 50, int $startAt = 0, string $orderBy = 'name'): ProjectSearchResult
     {

--- a/src/Repository/Project/VersionRepository.php
+++ b/src/Repository/Project/VersionRepository.php
@@ -6,7 +6,7 @@ use Xen3r0\JiraApiClient\Exception\Project\VersionMustBeExistsException;
 use Xen3r0\JiraApiClient\Model\Version\Version;
 use Xen3r0\JiraApiClient\Repository\AbstractRepository;
 
-class VersionRepository extends AbstractRepository implements VersionRepositoryInterface
+readonly class VersionRepository extends AbstractRepository implements VersionRepositoryInterface
 {
     public function findById(string $id): ?Version
     {

--- a/src/Serializer/Normalizer/Issue/CommentNormalizer.php
+++ b/src/Serializer/Normalizer/Issue/CommentNormalizer.php
@@ -9,7 +9,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Xen3r0\JiraApiClient\Model\Issue\Comment;
 
-class CommentNormalizer implements NormalizerInterface, DenormalizerInterface
+readonly class CommentNormalizer implements NormalizerInterface, DenormalizerInterface
 {
     public function __construct(
         private readonly ObjectNormalizer $objectNormalizer,

--- a/src/Serializer/Normalizer/Issue/FieldsNormalizer.php
+++ b/src/Serializer/Normalizer/Issue/FieldsNormalizer.php
@@ -10,7 +10,7 @@ use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Xen3r0\JiraApiClient\Model\Issue\CustomField;
 use Xen3r0\JiraApiClient\Model\Issue\Fields;
 
-class FieldsNormalizer implements NormalizerInterface, DenormalizerInterface
+readonly class FieldsNormalizer implements NormalizerInterface, DenormalizerInterface
 {
     public function __construct(
         private readonly ObjectNormalizer $objectNormalizer,

--- a/tests/Repository/Issue/CustomFieldOptionRepositoryTest.php
+++ b/tests/Repository/Issue/CustomFieldOptionRepositoryTest.php
@@ -3,7 +3,7 @@
 namespace Xen3r0\JiraApiClient\Tests\Repository\Issue;
 
 use Symfony\Contracts\HttpClient\ResponseInterface;
-use Xen3r0\JiraApiClient\Http\JiraClient;
+use Xen3r0\JiraApiClient\Http\JiraClientInterface;
 use Xen3r0\JiraApiClient\Model\Issue\CustomFieldContextOptionsList;
 use Xen3r0\JiraApiClient\Model\Issue\CustomFieldOption;
 use Xen3r0\JiraApiClient\Repository\Issue\CustomFieldOptionRepository;
@@ -14,7 +14,7 @@ class CustomFieldOptionRepositoryTest extends AbstractRepositoryTestCase
     public function testFindAll(): void
     {
         $content = $this->getFixtureContent('Issue/get_field_context_options.json');
-        $jiraClient = $this->createMock(JiraClient::class);
+        $jiraClient = $this->createMock(JiraClientInterface::class);
         $response = $this->createMock(ResponseInterface::class);
 
         $jiraClient
@@ -36,7 +36,7 @@ class CustomFieldOptionRepositoryTest extends AbstractRepositoryTestCase
     public function testFindById(): void
     {
         $content = $this->getFixtureContent('Issue/get_field_context_options.json');
-        $jiraClient = $this->createMock(JiraClient::class);
+        $jiraClient = $this->createMock(JiraClientInterface::class);
         $response = $this->createMock(ResponseInterface::class);
 
         $jiraClient
@@ -71,7 +71,7 @@ class CustomFieldOptionRepositoryTest extends AbstractRepositoryTestCase
         $result['options'][0]['id'] = '10001';
         $result['options'][1]['id'] = '10002';
 
-        $jiraClient = $this->createMock(JiraClient::class);
+        $jiraClient = $this->createMock(JiraClientInterface::class);
         $response = $this->createMock(ResponseInterface::class);
 
         $jiraClient
@@ -114,7 +114,7 @@ class CustomFieldOptionRepositoryTest extends AbstractRepositoryTestCase
         ];
         $result = [...$payload];
 
-        $jiraClient = $this->createMock(JiraClient::class);
+        $jiraClient = $this->createMock(JiraClientInterface::class);
         $response = $this->createMock(ResponseInterface::class);
 
         $jiraClient

--- a/tests/Repository/Issue/IssueCommentRepositoryTest.php
+++ b/tests/Repository/Issue/IssueCommentRepositoryTest.php
@@ -7,7 +7,7 @@ use DH\Adf\Node\Block\Paragraph;
 use DH\Adf\Node\Inline\Mention;
 use DH\Adf\Node\Inline\Text;
 use Symfony\Contracts\HttpClient\ResponseInterface;
-use Xen3r0\JiraApiClient\Http\JiraClient;
+use Xen3r0\JiraApiClient\Http\JiraClientInterface;
 use Xen3r0\JiraApiClient\Repository\Issue\IssueCommentRepository;
 use Xen3r0\JiraApiClient\Tests\Repository\AbstractRepositoryTestCase;
 
@@ -16,7 +16,7 @@ class IssueCommentRepositoryTest extends AbstractRepositoryTestCase
     public function testFindAll(): void
     {
         $content = $this->getFixtureContent('Issue/get_comments.json');
-        $jiraClient = $this->createMock(JiraClient::class);
+        $jiraClient = $this->createMock(JiraClientInterface::class);
         $response = $this->createMock(ResponseInterface::class);
 
         $jiraClient
@@ -38,7 +38,7 @@ class IssueCommentRepositoryTest extends AbstractRepositoryTestCase
     public function testFindById(): void
     {
         $content = $this->getFixtureContent('Issue/get_comment.json');
-        $jiraClient = $this->createMock(JiraClient::class);
+        $jiraClient = $this->createMock(JiraClientInterface::class);
         $response = $this->createMock(ResponseInterface::class);
 
         $jiraClient

--- a/tests/Repository/Issue/IssueRepositoryTest.php
+++ b/tests/Repository/Issue/IssueRepositoryTest.php
@@ -7,7 +7,7 @@ use DH\Adf\Node\Block\Paragraph;
 use DH\Adf\Node\Inline\Text;
 use DH\Adf\Node\Mark\Strong;
 use Symfony\Contracts\HttpClient\ResponseInterface;
-use Xen3r0\JiraApiClient\Http\JiraClient;
+use Xen3r0\JiraApiClient\Http\JiraClientInterface;
 use Xen3r0\JiraApiClient\Repository\Issue\IssueRepository;
 use Xen3r0\JiraApiClient\Tests\Repository\AbstractRepositoryTestCase;
 
@@ -16,7 +16,7 @@ class IssueRepositoryTest extends AbstractRepositoryTestCase
     public function testFindAll(): void
     {
         $content = $this->getFixtureContent('Issue/post_issue_search_jql.json');
-        $jiraClient = $this->createMock(JiraClient::class);
+        $jiraClient = $this->createMock(JiraClientInterface::class);
         $response = $this->createMock(ResponseInterface::class);
 
         $jiraClient
@@ -47,7 +47,7 @@ class IssueRepositoryTest extends AbstractRepositoryTestCase
     public function testFindByIdOrKey(): void
     {
         $content = $this->getFixtureContent('Issue/get_issue.json');
-        $jiraClient = $this->createMock(JiraClient::class);
+        $jiraClient = $this->createMock(JiraClientInterface::class);
         $response = $this->createMock(ResponseInterface::class);
 
         $jiraClient

--- a/tests/Repository/Project/ProjectRepositoryTest.php
+++ b/tests/Repository/Project/ProjectRepositoryTest.php
@@ -3,7 +3,7 @@
 namespace Xen3r0\JiraApiClient\Tests\Repository\Project;
 
 use Symfony\Contracts\HttpClient\ResponseInterface;
-use Xen3r0\JiraApiClient\Http\JiraClient;
+use Xen3r0\JiraApiClient\Http\JiraClientInterface;
 use Xen3r0\JiraApiClient\Repository\Project\ProjectRepository;
 use Xen3r0\JiraApiClient\Tests\Repository\AbstractRepositoryTestCase;
 
@@ -12,7 +12,7 @@ class ProjectRepositoryTest extends AbstractRepositoryTestCase
     public function testFindAll(): void
     {
         $content = $this->getFixtureContent('Project/get_project_search.json');
-        $jiraClient = $this->createMock(JiraClient::class);
+        $jiraClient = $this->createMock(JiraClientInterface::class);
         $response = $this->createMock(ResponseInterface::class);
 
         $jiraClient
@@ -34,7 +34,7 @@ class ProjectRepositoryTest extends AbstractRepositoryTestCase
     public function testFindByIdOrKey(): void
     {
         $content = $this->getFixtureContent('Project/get_project.json');
-        $jiraClient = $this->createMock(JiraClient::class);
+        $jiraClient = $this->createMock(JiraClientInterface::class);
         $response = $this->createMock(ResponseInterface::class);
 
         $jiraClient

--- a/tests/Repository/Project/VersionRepositoryTest.php
+++ b/tests/Repository/Project/VersionRepositoryTest.php
@@ -4,7 +4,7 @@ namespace Xen3r0\JiraApiClient\Tests\Repository\Project;
 
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Xen3r0\JiraApiClient\Exception\Project\VersionMustBeExistsException;
-use Xen3r0\JiraApiClient\Http\JiraClient;
+use Xen3r0\JiraApiClient\Http\JiraClientInterface;
 use Xen3r0\JiraApiClient\Model\Version\Version;
 use Xen3r0\JiraApiClient\Repository\Project\VersionRepository;
 use Xen3r0\JiraApiClient\Tests\Repository\AbstractRepositoryTestCase;
@@ -14,7 +14,7 @@ class VersionRepositoryTest extends AbstractRepositoryTestCase
     public function testFindById(): void
     {
         $content = $this->getFixtureContent('Project/get_version.json');
-        $jiraClient = $this->createMock(JiraClient::class);
+        $jiraClient = $this->createMock(JiraClientInterface::class);
         $response = $this->createMock(ResponseInterface::class);
 
         $jiraClient
@@ -46,7 +46,7 @@ class VersionRepositoryTest extends AbstractRepositoryTestCase
         $payload = ['name' => '2.1.0', 'description' => 'Release 2.1.0', 'archived' => false, 'released' => false, 'releaseDate' => '2025-08-18T00:00:00+00:00'];
         $result = ['id' => '2000', ...$payload];
 
-        $jiraClient = $this->createMock(JiraClient::class);
+        $jiraClient = $this->createMock(JiraClientInterface::class);
         $response = $this->createMock(ResponseInterface::class);
 
         $jiraClient
@@ -80,7 +80,7 @@ class VersionRepositoryTest extends AbstractRepositoryTestCase
         $payload = ['id' => '2000', 'name' => '2.1.0', 'description' => 'Release 2.1.0', 'archived' => false, 'released' => false, 'releaseDate' => '2025-08-18T00:00:00+00:00'];
         $result = [...$payload];
 
-        $jiraClient = $this->createMock(JiraClient::class);
+        $jiraClient = $this->createMock(JiraClientInterface::class);
         $response = $this->createMock(ResponseInterface::class);
 
         $jiraClient
@@ -111,7 +111,7 @@ class VersionRepositoryTest extends AbstractRepositoryTestCase
             ->setDescription('Release 2.1.0')
             ->setReleaseDate(new \DateTimeImmutable('2025-08-18'));
 
-        $jiraClient = $this->createMock(JiraClient::class);
+        $jiraClient = $this->createMock(JiraClientInterface::class);
 
         $this->expectException(VersionMustBeExistsException::class);
 
@@ -123,7 +123,7 @@ class VersionRepositoryTest extends AbstractRepositoryTestCase
     {
         $versionId = '2000';
 
-        $jiraClient = $this->createMock(JiraClient::class);
+        $jiraClient = $this->createMock(JiraClientInterface::class);
         $response = $this->createMock(ResponseInterface::class);
 
         $jiraClient


### PR DESCRIPTION
## Summary
- Raise the minimum PHP version from 8.1 to 8.2 (composer.json, CI matrix, README, CONTRIBUTING, Dockerfile)
- Mark `Configuration::setPassword()`/`create()` password parameter as `#[\SensitiveParameter]` so it's redacted from stack traces
- Convert `JiraClient`, `AbstractRepository` (and its repository subclasses), `FieldsNormalizer` and `CommentNormalizer` to `readonly class`, since all their properties are already single-assignment
- Update repository tests to mock `JiraClientInterface` instead of the now-readonly `JiraClient` concrete class (PHPUnit cannot double readonly classes)

## Test plan
- [x] `docker compose build` (PHP 8.2 image) + `composer install`
- [x] `vendor/bin/phpunit` (19 tests, 95 assertions, OK)
- [x] `vendor/bin/phpstan analyse` (level 8, no errors)
- [x] `vendor/bin/php-cs-fixer fix --dry-run --diff` (0 files to fix)