### PR TITLE
ci: show coverage in job summary instead of PR comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,6 @@ jobs:
 
     tests:
         runs-on: ${{ matrix.operating-system }}
-        permissions:
-            pull-requests: write
         strategy:
             matrix:
                 operating-system: [ ubuntu-latest ]
@@ -100,10 +98,6 @@ jobs:
                   format: markdown
                   output: both
 
-            - name: Comment coverage summary on PR
-              if: matrix.php-versions == '8.2' && github.event_name == 'pull_request'
-              uses: marocchino/sticky-pull-request-comment@v2
-              continue-on-error: true
-              with:
-                  header: coverage
-                  path: code-coverage-results.md
+            - name: Add coverage summary to job summary
+              if: matrix.php-versions == '8.2'
+              run: cat code-coverage-results.md >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Drop the `marocchino/sticky-pull-request-comment` step: PR comments trigger email notifications to every repo watcher on each push, which is noisy
- Write the coverage summary to `$GITHUB_STEP_SUMMARY` instead — still visible directly on the workflow run / PR checks tab, just without emailing anyone

## Test plan
- [x] YAML validated
- [ ] Confirm the coverage summary renders correctly in the Actions run summary