### PR TITLE
ci: bump actions to Node.js 24 runtime versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
         name: Coding standards
         steps:
             - name: checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   ref: ${{ github.head_ref }}
 
@@ -26,7 +26,7 @@ jobs:
               run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             - name: Cache composer dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v6
               with:
                   path: ${{ steps.composer-cache.outputs.dir }}
                   key: ${{ runner.os }}-composer-8.2-${{ hashFiles('**/composer.lock') }}
@@ -49,7 +49,7 @@ jobs:
         name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
         steps:
             - name: checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   ref: ${{ github.head_ref }}
 
@@ -66,7 +66,7 @@ jobs:
               run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             - name: Cache composer dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v6
               with:
                   path: ${{ steps.composer-cache.outputs.dir }}
                   key: ${{ runner.os }}-composer-${{ matrix.php-versions }}-${{ hashFiles('**/composer.lock') }}
@@ -84,7 +84,7 @@ jobs:
 
             - name: Upload coverage report
               if: matrix.php-versions == '8.2'
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: coverage-report
                   path: coverage.xml


### PR DESCRIPTION
## Summary
- Bump `actions/checkout@v4` → `@v7`, `actions/cache@v4` → `@v6`, `actions/upload-artifact@v4` → `@v7`
- These are the first major versions of each action to declare `runs.using: node24` natively; v4 still targets Node 20 and is being force-run on Node 24 with a deprecation warning ahead of Node 20's removal from GitHub-hosted runners (2026-09-16)
- Verified via each action's changelog: no breaking behavior change for our usage (plain checkout, composer cache path/key, single artifact upload)

## Test plan
- [x] YAML validated
- [ ] Confirm CI runs green with no Node deprecation warnings